### PR TITLE
Reworked the PHP OOP Design

### DIFF
--- a/php/ChatterBotApi/ChatterBot.php
+++ b/php/ChatterBotApi/ChatterBot.php
@@ -1,0 +1,34 @@
+<?php namespace ChatterBotApi;
+
+/*
+ * ChatterBotAPI
+ * Copyright (C) 2011 pierredavidbelanger@gmail.com
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Abstract for all ChatterBots
+ */
+abstract class ChatterBot
+{
+	/**
+	 * Create the session
+	 * @return \ChatterBotApi\ChatterBotSession The new session instance
+	 */
+	public function createSession()
+	{
+		return null;
+	}
+} 

--- a/php/ChatterBotApi/ChatterBotFactory.php
+++ b/php/ChatterBotApi/ChatterBotFactory.php
@@ -1,0 +1,58 @@
+<?php namespace ChatterBotApi;
+
+/*
+ * ChatterBotAPI
+ * Copyright (C) 2011 pierredavidbelanger@gmail.com
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Exception;
+
+/** 
+ * The ChatterBotFactory
+ */
+class ChatterBotFactory
+{
+	/**
+	 * Create a new a ChatterBot
+	 * @param  int    $type The ChatterBotType (hint: use the ChatterBotType constants)
+	 * @param  string $arg  BotId (only needed when using a PandoraBot)
+	 *
+	 * @return \ChatterBotApi\ChatterBot       The new Bot instance
+	 *
+	 * @throws \Exception When type not recognized or no BotId bassed to the PandoraBot
+	 */
+	public function create($type, $arg = null)
+	{
+		switch ($type) {
+			case ChatterBotType::CLEVERBOT:
+				return new _Cleverbot('http://www.cleverbot.com/webservicemin');
+			
+
+			case ChatterBotType::JABBERWACKY:
+				return new _Cleverbot('http://jabberwacky.com/webservicemin');
+			
+			case ChatterBotType::PANDORABOTS:
+				if ($arg == null) {
+					throw new Exception('PANDORABOTS needs a botid arg');
+				}
+			return new _Pandorabots($arg);
+
+			default:
+				throw new Exception('Type not recognized');
+				
+		}
+	}
+}

--- a/php/ChatterBotApi/ChatterBotFactory.php
+++ b/php/ChatterBotApi/ChatterBotFactory.php
@@ -19,6 +19,8 @@
  */
 
 use Exception;
+use ChatterBotApi\Implementation\CleverBot\CleverBot;
+use ChatterBotApi\Implementation\PandoraBots\PandoraBots;
 
 /** 
  * The ChatterBotFactory
@@ -34,21 +36,21 @@ class ChatterBotFactory
 	 *
 	 * @throws \Exception When type not recognized or no BotId bassed to the PandoraBot
 	 */
-	public function create($type, $arg = null)
+	public static function create($type, $arg = null)
 	{
 		switch ($type) {
 			case ChatterBotType::CLEVERBOT:
-				return new _Cleverbot('http://www.cleverbot.com/webservicemin');
+				return new Cleverbot('http://www.cleverbot.com/webservicemin');
 			
 
 			case ChatterBotType::JABBERWACKY:
-				return new _Cleverbot('http://jabberwacky.com/webservicemin');
+				return new Cleverbot('http://jabberwacky.com/webservicemin');
 			
 			case ChatterBotType::PANDORABOTS:
 				if ($arg == null) {
 					throw new Exception('PANDORABOTS needs a botid arg');
 				}
-			return new _Pandorabots($arg);
+			return new PandoraBots($arg);
 
 			default:
 				throw new Exception('Type not recognized');

--- a/php/ChatterBotApi/ChatterBotSession.php
+++ b/php/ChatterBotApi/ChatterBotSession.php
@@ -1,0 +1,48 @@
+<?php namespace ChatterBotApi;
+
+/*
+ * ChatterBotAPI
+ * Copyright (C) 2011 pierredavidbelanger@gmail.com
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Abstract for all ChatterBot Sessions
+ */
+abstract class ChatterBotSession
+{
+	/**
+	 * Return new thought based on given thought
+	 * @param  \ChatterBotApi\ChatterBotTought $thought The previous thought
+	 * @return \ChatterBotApi\ChatterBotTought          The new thought.
+	 */
+	public function thinkThought($thought)
+	{
+		return $thought;
+	}
+
+	/**
+	 * Return a new thought based on given string
+	 * @param  string $text The text
+	 * 
+	 * @return \ChatterBotApi\ChatterBotTought    The new thought.
+	 */
+	public function think($text)
+	{
+		$thought = new ChatterBotThought();
+		$thought->setText($text);
+		return $this->thinkThought($thought)->getText();
+	}
+}

--- a/php/ChatterBotApi/ChatterBotSession.php
+++ b/php/ChatterBotApi/ChatterBotSession.php
@@ -25,10 +25,10 @@ abstract class ChatterBotSession
 {
 	/**
 	 * Return new thought based on given thought
-	 * @param  \ChatterBotApi\ChatterBotTought $thought The previous thought
-	 * @return \ChatterBotApi\ChatterBotTought          The new thought.
+	 * @param  \ChatterBotApi\ChatterBotThought $thought The previous thought
+	 * @return \ChatterBotApi\ChatterBotThought          The new thought.
 	 */
-	public function thinkThought($thought)
+	public function thinkThought(ChatterBotThought $thought)
 	{
 		return $thought;
 	}
@@ -37,7 +37,7 @@ abstract class ChatterBotSession
 	 * Return a new thought based on given string
 	 * @param  string $text The text
 	 * 
-	 * @return \ChatterBotApi\ChatterBotTought    The new thought.
+	 * @return \ChatterBotApi\ChatterBotThought    The new thought.
 	 */
 	public function think($text)
 	{

--- a/php/ChatterBotApi/ChatterBotThought.php
+++ b/php/ChatterBotApi/ChatterBotThought.php
@@ -1,0 +1,49 @@
+<?php namespace ChatterBotApi;
+
+/*
+ * ChatterBotAPI
+ * Copyright (C) 2011 pierredavidbelanger@gmail.com
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** 
+ * A ChatterBot thought
+ */
+class ChatterBotThought
+{
+	/**
+	 * The associated Text
+	 * @var string
+	 */
+	private $text;
+
+	/**
+	 * Get the text of this thought
+	 * @return string The text
+	 */
+	public function getText()
+	{
+		return $this->text;
+	}
+
+	/**
+	 * Set the text of this thought
+	 * @param string $text The text
+	 */
+	public function setText($text)
+	{
+		$this->text = $text;
+	}
+}

--- a/php/ChatterBotApi/ChatterBotType.php
+++ b/php/ChatterBotApi/ChatterBotType.php
@@ -1,0 +1,43 @@
+<?php namespace ChatterBotApi;
+
+/*
+ * ChatterBotAPI
+ * Copyright (C) 2011 pierredavidbelanger@gmail.com
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The ChatterBot type
+ */
+class ChatterBotType
+{
+	/**
+	 * CleverBot
+	 * @var int 1
+	 */
+	const CLEVERBOT = 1;
+	
+	/**
+	 * JabberWacky
+	 * @var int 2
+	 */
+	const JABBERWACKY = 2;
+	
+	/**
+	 * PandoraBot
+	 * @var int 3
+	 */
+	const PANDORABOTS = 3;
+}

--- a/php/ChatterBotApi/Implementation/CleverBot/CleverBot.php
+++ b/php/ChatterBotApi/Implementation/CleverBot/CleverBot.php
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-use ChatterBotApi;
+use ChatterBotApi\ChatterBot;
 
 /**
  * A cleverbot
@@ -64,6 +64,6 @@ class CleverBot extends ChatterBot
 	 */
 	public function createSession()
 	{
-		return new _CleverbotSession($this);
+		return new Session($this);
 	}
 }

--- a/php/ChatterBotApi/Implementation/CleverBot/CleverBot.php
+++ b/php/ChatterBotApi/Implementation/CleverBot/CleverBot.php
@@ -1,0 +1,69 @@
+<?php namespace ChatterBotApi\Implementation\CleverBot;
+
+/*
+ * ChatterBotAPI
+ * Copyright (C) 2011 pierredavidbelanger@gmail.com
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use ChatterBotApi;
+
+/**
+ * A cleverbot
+ */
+class CleverBot extends ChatterBot
+{
+	/**
+	 * The url for this chatterbot
+	 * @var string
+	 */
+	private $url;
+
+	/**
+	 * Constructor.
+	 * @param string $url The url for this chatterbot
+	 */
+	public function __construct($url)
+	{
+		$this->url = $url;
+	}
+
+	/**
+	 * Get the url of this chatterbot
+	 * @return string The url
+	 */
+	public function getUrl()
+	{
+		return $this->url;
+	}
+
+	/**
+	 * Set the url for this chatterbot
+	 * @param string $url The url
+	 */
+	public function setUrl($url)
+	{
+		$this->url = $url;
+	}
+
+	/**
+	 * Create a new Session for this bot
+	 * @return \ChatterBotApi\Implementation\CleverBot\Session The new Session
+	 */
+	public function createSession()
+	{
+		return new _CleverbotSession($this);
+	}
+}

--- a/php/ChatterBotApi/Implementation/CleverBot/Session.php
+++ b/php/ChatterBotApi/Implementation/CleverBot/Session.php
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+use ChatterBotApi\Utils;
 use ChatterBotApi\ChatterBotThought;
 use ChatterBotApi\ChatterBotSession;
 
@@ -63,34 +64,34 @@ class Session extends ChatterBotSession
 		$dataToDigest = substr($data, 9, 20);
 		$dataDigest = md5($dataToDigest);
 		$this->vars['icognocheck'] = $dataDigest;
-		$response = _utils_post($this->bot->getUrl(), $this->vars);
-		$responseValues = split("\r", $response);
-		//self.vars['??'] = _utils_string_at_index($responseValues, 0);
-		$this->vars['sessionid'] = _utils_string_at_index($responseValues, 1);
-		$this->vars['logurl'] = _utils_string_at_index($responseValues, 2);
-		$this->vars['vText8'] = _utils_string_at_index($responseValues, 3);
-		$this->vars['vText7'] = _utils_string_at_index($responseValues, 4);
-		$this->vars['vText6'] = _utils_string_at_index($responseValues, 5);
-		$this->vars['vText5'] = _utils_string_at_index($responseValues, 6);
-		$this->vars['vText4'] = _utils_string_at_index($responseValues, 7);
-		$this->vars['vText3'] = _utils_string_at_index($responseValues, 8);
-		$this->vars['vText2'] = _utils_string_at_index($responseValues, 9);
-		$this->vars['prevref'] = _utils_string_at_index($responseValues, 10);
-		//$this->vars['??'] = _utils_string_at_index($responseValues, 11);
-		$this->vars['emotionalhistory'] = _utils_string_at_index($responseValues, 12);
-		$this->vars['ttsLocMP3'] = _utils_string_at_index($responseValues, 13);
-		$this->vars['ttsLocTXT'] = _utils_string_at_index($responseValues, 14);
-		$this->vars['ttsLocTXT3'] = _utils_string_at_index($responseValues, 15);
-		$this->vars['ttsText'] = _utils_string_at_index($responseValues, 16);
-		$this->vars['lineRef'] = _utils_string_at_index($responseValues, 17);
-		$this->vars['lineURL'] = _utils_string_at_index($responseValues, 18);
-		$this->vars['linePOST'] = _utils_string_at_index($responseValues, 19);
-		$this->vars['lineChoices'] = _utils_string_at_index($responseValues, 20);
-		$this->vars['lineChoicesAbbrev'] = _utils_string_at_index($responseValues, 21);
-		$this->vars['typingData'] = _utils_string_at_index($responseValues, 22);
-		$this->vars['divert'] = _utils_string_at_index($responseValues, 23);
+		$response = Utils::post($this->bot->getUrl(), $this->vars);
+		$responseValues = explode("\r", $response);
+		//self.vars['??'] = Utils::stringAtIndex($responseValues, 0);
+		$this->vars['sessionid'] = Utils::stringAtIndex($responseValues, 1);
+		$this->vars['logurl'] = Utils::stringAtIndex($responseValues, 2);
+		$this->vars['vText8'] = Utils::stringAtIndex($responseValues, 3);
+		$this->vars['vText7'] = Utils::stringAtIndex($responseValues, 4);
+		$this->vars['vText6'] = Utils::stringAtIndex($responseValues, 5);
+		$this->vars['vText5'] = Utils::stringAtIndex($responseValues, 6);
+		$this->vars['vText4'] = Utils::stringAtIndex($responseValues, 7);
+		$this->vars['vText3'] = Utils::stringAtIndex($responseValues, 8);
+		$this->vars['vText2'] = Utils::stringAtIndex($responseValues, 9);
+		$this->vars['prevref'] = Utils::stringAtIndex($responseValues, 10);
+		//$this->vars['??'] = Utils::stringAtIndex($responseValues, 11);
+		$this->vars['emotionalhistory'] = Utils::stringAtIndex($responseValues, 12);
+		$this->vars['ttsLocMP3'] = Utils::stringAtIndex($responseValues, 13);
+		$this->vars['ttsLocTXT'] = Utils::stringAtIndex($responseValues, 14);
+		$this->vars['ttsLocTXT3'] = Utils::stringAtIndex($responseValues, 15);
+		$this->vars['ttsText'] = Utils::stringAtIndex($responseValues, 16);
+		$this->vars['lineRef'] = Utils::stringAtIndex($responseValues, 17);
+		$this->vars['lineURL'] = Utils::stringAtIndex($responseValues, 18);
+		$this->vars['linePOST'] = Utils::stringAtIndex($responseValues, 19);
+		$this->vars['lineChoices'] = Utils::stringAtIndex($responseValues, 20);
+		$this->vars['lineChoicesAbbrev'] = Utils::stringAtIndex($responseValues, 21);
+		$this->vars['typingData'] = Utils::stringAtIndex($responseValues, 22);
+		$this->vars['divert'] = Utils::stringAtIndex($responseValues, 23);
 		$responseThought = new ChatterBotThought();
-		$responseThought->setText(_utils_string_at_index($responseValues, 16));
+		$responseThought->setText(Utils::stringAtIndex($responseValues, 16));
 		return $responseThought;
 	}
 }

--- a/php/ChatterBotApi/Implementation/CleverBot/Session.php
+++ b/php/ChatterBotApi/Implementation/CleverBot/Session.php
@@ -1,0 +1,95 @@
+<?php namespace ChatterBotApi\Implementation\CleverBot;
+
+/*
+ * ChatterBotAPI
+ * Copyright (C) 2011 pierredavidbelanger@gmail.com
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use ChatterBotApi;
+
+class Session extends ChatterBotSession
+{
+	/**
+	 * The assoc. bot of this session
+	 * @var [type]
+	 */
+	private $bot;
+
+	/**
+	 * Varibales used for creating the request
+	 * @var array
+	 */
+	private $vars;
+
+	/**
+	 * Constructor.
+	 * @param \ChatterBotApi\Implementation\CleverBot\CleverBot $bot The bot
+	 */
+	public function __construct($bot)
+	{
+		$this->bot = $bot;
+		$this->vars = array();
+		$this->vars['start'] = 'y';
+		$this->vars['icognoid'] = 'wsf';
+		$this->vars['fno'] = '0';
+		$this->vars['sub'] = 'Say';
+		$this->vars['islearning'] = '1';
+		$this->vars['cleanslate'] = 'false';
+	}
+
+	/**
+	 * Return new thought based on given thought
+	 * @param  \ChatterBotApi\ChatterBotTought $thought The previous thought
+	 * @return \ChatterBotApi\ChatterBotTought          The new thought.
+	 */
+	public function thinkThought($thought)
+	{
+		$this->vars['stimulus'] = $thought->getText();
+		$data = http_build_query($this->vars);
+		$dataToDigest = substr($data, 9, 20);
+		$dataDigest = md5($dataToDigest);
+		$this->vars['icognocheck'] = $dataDigest;
+		$response = _utils_post($this->bot->getUrl(), $this->vars);
+		$responseValues = split("\r", $response);
+		//self.vars['??'] = _utils_string_at_index($responseValues, 0);
+		$this->vars['sessionid'] = _utils_string_at_index($responseValues, 1);
+		$this->vars['logurl'] = _utils_string_at_index($responseValues, 2);
+		$this->vars['vText8'] = _utils_string_at_index($responseValues, 3);
+		$this->vars['vText7'] = _utils_string_at_index($responseValues, 4);
+		$this->vars['vText6'] = _utils_string_at_index($responseValues, 5);
+		$this->vars['vText5'] = _utils_string_at_index($responseValues, 6);
+		$this->vars['vText4'] = _utils_string_at_index($responseValues, 7);
+		$this->vars['vText3'] = _utils_string_at_index($responseValues, 8);
+		$this->vars['vText2'] = _utils_string_at_index($responseValues, 9);
+		$this->vars['prevref'] = _utils_string_at_index($responseValues, 10);
+		//$this->vars['??'] = _utils_string_at_index($responseValues, 11);
+		$this->vars['emotionalhistory'] = _utils_string_at_index($responseValues, 12);
+		$this->vars['ttsLocMP3'] = _utils_string_at_index($responseValues, 13);
+		$this->vars['ttsLocTXT'] = _utils_string_at_index($responseValues, 14);
+		$this->vars['ttsLocTXT3'] = _utils_string_at_index($responseValues, 15);
+		$this->vars['ttsText'] = _utils_string_at_index($responseValues, 16);
+		$this->vars['lineRef'] = _utils_string_at_index($responseValues, 17);
+		$this->vars['lineURL'] = _utils_string_at_index($responseValues, 18);
+		$this->vars['linePOST'] = _utils_string_at_index($responseValues, 19);
+		$this->vars['lineChoices'] = _utils_string_at_index($responseValues, 20);
+		$this->vars['lineChoicesAbbrev'] = _utils_string_at_index($responseValues, 21);
+		$this->vars['typingData'] = _utils_string_at_index($responseValues, 22);
+		$this->vars['divert'] = _utils_string_at_index($responseValues, 23);
+		$responseThought = new ChatterBotThought();
+		$responseThought->setText(_utils_string_at_index($responseValues, 16));
+		return $responseThought;
+	}
+}

--- a/php/ChatterBotApi/Implementation/CleverBot/Session.php
+++ b/php/ChatterBotApi/Implementation/CleverBot/Session.php
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-use ChatterBotApi\ChatterBotTought;
+use ChatterBotApi\ChatterBotThought;
 use ChatterBotApi\ChatterBotSession;
 
 class Session extends ChatterBotSession
@@ -56,7 +56,7 @@ class Session extends ChatterBotSession
 	 * @param  \ChatterBotApi\ChatterBotTought $thought The previous thought
 	 * @return \ChatterBotApi\ChatterBotTought          The new thought.
 	 */
-	public function thinkThought(ChatterBotTought $thought)
+	public function thinkThought(ChatterBotThought $thought)
 	{
 		$this->vars['stimulus'] = $thought->getText();
 		$data = http_build_query($this->vars);

--- a/php/ChatterBotApi/Implementation/CleverBot/Session.php
+++ b/php/ChatterBotApi/Implementation/CleverBot/Session.php
@@ -18,13 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-use ChatterBotApi;
+use ChatterBotApi\ChatterBotTought;
+use ChatterBotApi\ChatterBotSession;
 
 class Session extends ChatterBotSession
 {
 	/**
 	 * The assoc. bot of this session
-	 * @var [type]
+	 * @var \ChatterBotApi\Implementation\CleverBot\CleverBot
 	 */
 	private $bot;
 
@@ -38,7 +39,7 @@ class Session extends ChatterBotSession
 	 * Constructor.
 	 * @param \ChatterBotApi\Implementation\CleverBot\CleverBot $bot The bot
 	 */
-	public function __construct($bot)
+	public function __construct(CleverBot $bot)
 	{
 		$this->bot = $bot;
 		$this->vars = array();
@@ -55,7 +56,7 @@ class Session extends ChatterBotSession
 	 * @param  \ChatterBotApi\ChatterBotTought $thought The previous thought
 	 * @return \ChatterBotApi\ChatterBotTought          The new thought.
 	 */
-	public function thinkThought($thought)
+	public function thinkThought(ChatterBotTought $thought)
 	{
 		$this->vars['stimulus'] = $thought->getText();
 		$data = http_build_query($this->vars);

--- a/php/ChatterBotApi/Implementation/PandoraBots/PandoraBots.php
+++ b/php/ChatterBotApi/Implementation/PandoraBots/PandoraBots.php
@@ -1,0 +1,69 @@
+<?php namespace ChatterBotApi\Implementation\PandoraBots;
+
+/*
+ * ChatterBotAPI
+ * Copyright (C) 2011 pierredavidbelanger@gmail.com
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use ChatterBotApi;
+
+/**
+ * A Pandora Bot
+ */
+class PandoraBots extends ChatterBot
+{	
+	/**
+	 * The BotID
+	 * @var string
+	 */
+	private $botid;
+
+	/**
+	 * Constructor.
+	 * @param string $botid The Bot ID
+	 */
+	public function __construct($botid)
+	{
+		$this->botid = $botid;
+	}
+
+	/**
+	 * Returns the bot ID
+	 * @return string The bot ID
+	 */
+	public function getBotid()
+	{
+		return $this->botid;
+	}
+
+	/**
+	 * Set the bot ID
+	 * @param string $botid The bot ID
+	 */
+	public function setBotid($botid)
+	{
+		$this->botid = $botid;
+	}        
+
+	/**
+	 * Create a new Session for this bot
+	 * @return \ChatterBotApi\Implementation\PandoraBots\Session The new Session
+	 */
+	public function createSession()
+	{
+		return new Session($this);
+	}
+}

--- a/php/ChatterBotApi/Implementation/PandoraBots/PandoraBots.php
+++ b/php/ChatterBotApi/Implementation/PandoraBots/PandoraBots.php
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-use ChatterBotApi;
+use ChatterBotApi\ChatterBot;
 
 /**
  * A Pandora Bot

--- a/php/ChatterBotApi/Implementation/PandoraBots/Session.php
+++ b/php/ChatterBotApi/Implementation/PandoraBots/Session.php
@@ -19,6 +19,7 @@
  */
 
 use SimpleXMLElement;
+use ChatterBotApi\Utils;
 use ChatterBotApi\ChatterBotSession;
 use ChatterBotApi\ChatterBotThought;
 
@@ -49,11 +50,17 @@ class Session extends ChatterBotSession
 	public function thinkThought(ChatterBotThought $thought)
 	{
 		$this->vars['input'] = $thought->getText();
-		$response = _utils_post('http://www.pandorabots.com/pandora/talk-xml', $this->vars);
+		$response = Utils::post('http://www.pandorabots.com/pandora/talk-xml', $this->vars);
 		$element = new SimpleXMLElement($response);
 		$result = $element->xpath('//result/that/text()');
 		$responseThought = new ChatterBotThought();
-		$responseThought->setText($result[0][0]);
+
+		if (isset($result[0][0])) {
+			$responseThought->setText($result[0][0]);
+		} else { // Happens hardly ever
+			$responseThought->setText('');
+		}
+		
 		return $responseThought;
 	}
 }

--- a/php/ChatterBotApi/Implementation/PandoraBots/Session.php
+++ b/php/ChatterBotApi/Implementation/PandoraBots/Session.php
@@ -46,7 +46,7 @@ class Session extends ChatterBotSession
 	 * @param  \ChatterBotApi\ChatterBotTought $thought The previous thought
 	 * @return \ChatterBotApi\ChatterBotTought          The new thought.
 	 */
-	public function thinkThought(ChatterBotTought $thought)
+	public function thinkThought(ChatterBotThought $thought)
 	{
 		$this->vars['input'] = $thought->getText();
 		$response = _utils_post('http://www.pandorabots.com/pandora/talk-xml', $this->vars);

--- a/php/ChatterBotApi/Implementation/PandoraBots/Session.php
+++ b/php/ChatterBotApi/Implementation/PandoraBots/Session.php
@@ -1,0 +1,59 @@
+<?php namespace ChatterBotApi\Implementation\PandoraBots;
+
+/*
+ * ChatterBotAPI
+ * Copyright (C) 2011 pierredavidbelanger@gmail.com
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use SimpleXMLElement;
+use ChatterBotApi\ChatterBotSession;
+use ChatterBotApi\ChatterBotThought;
+
+class Session extends ChatterBotSession
+{
+	/**
+	 * Varibales used for creating the request
+	 * @var array
+	 */
+	private $vars;
+
+	/**
+	 * Constructor.
+	 * @param \ChatterBotApi\Implementation\PandoraBots $bot The bot
+	 */
+	public function __construct(PandoraBots $bot)
+	{
+		$this->vars = array();
+		$this->vars['botid'] = $bot->getBotid();
+		$this->vars['custid'] = uniqid();
+	}
+
+	/**
+	 * Return new thought based on given thought
+	 * @param  \ChatterBotApi\ChatterBotTought $thought The previous thought
+	 * @return \ChatterBotApi\ChatterBotTought          The new thought.
+	 */
+	public function thinkThought(ChatterBotTought $thought)
+	{
+		$this->vars['input'] = $thought->getText();
+		$response = _utils_post('http://www.pandorabots.com/pandora/talk-xml', $this->vars);
+		$element = new SimpleXMLElement($response);
+		$result = $element->xpath('//result/that/text()');
+		$responseThought = new ChatterBotThought();
+		$responseThought->setText($result[0][0]);
+		return $responseThought;
+	}
+}

--- a/php/ChatterBotApi/Utils.php
+++ b/php/ChatterBotApi/Utils.php
@@ -1,0 +1,60 @@
+<?php namespace ChatterBotApi;
+
+/*
+ * ChatterBotAPI
+ * Copyright (C) 2011 pierredavidbelanger@gmail.com
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+/**
+ * Utils class 
+ */
+class Utils
+{
+	/**
+	 * Post to the given URL
+	 * @param  string $url    The target url
+	 * @param  array  $params The parameters
+	 * @return string         The response
+	 */
+	public static function post($url, $params)
+	{
+		$contextParams = array();
+		$contextParams['http'] = array();
+		$contextParams['http']['method'] = 'POST';
+		$contextParams['http']['content'] = http_build_query($params);
+		$context = stream_context_create($contextParams);
+		$fp = fopen($url, 'rb', false, $context);
+		$response = stream_get_contents($fp);
+		fclose($fp);
+		return $response;
+	}
+
+	/**
+	 * Returns the string at the given index
+	 * @param  array  $strings The strings
+	 * @param  int    $index   The index
+	 * @return string          The string | ''
+	 */
+	public static function stringAtIndex($strings, $index)
+	{
+		if (count($strings) > $index) {
+			return $strings[$index];
+		} else {
+			return '';
+		}
+	}
+}

--- a/php/ChatterBotApi/Utils.php
+++ b/php/ChatterBotApi/Utils.php
@@ -36,6 +36,7 @@ class Utils
 		$contextParams['http'] = array();
 		$contextParams['http']['method'] = 'POST';
 		$contextParams['http']['content'] = http_build_query($params);
+		$contextParams['http']['header'] = "Content-Type: application/x-www-form-urlencoded\r\n";
 		$context = stream_context_create($contextParams);
 		$fp = fopen($url, 'rb', false, $context);
 		$response = stream_get_contents($fp);

--- a/php/ChatterBotApiTestOOP.php
+++ b/php/ChatterBotApiTestOOP.php
@@ -1,0 +1,37 @@
+<?php
+    /*
+     ChatterBotAPI
+     Copyright (C) 2011 pierredavidbelanger@gmail.com
+     
+     This program is free software: you can redistribute it and/or modify
+     it under the terms of the GNU Lesser General Public License as published by
+     the Free Software Foundation, either version 3 of the License, or
+     (at your option) any later version.
+     
+     This program is distributed in the hope that it will be useful,
+     but WITHOUT ANY WARRANTY; without even the implied warranty of
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     GNU Lesser General Public License for more details.
+     
+     You should have received a copy of the GNU Lesser General Public License
+     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    */
+    
+    /**
+     * This tests were written by:
+     * Christian Gaertner <christiangaertner.film@googlemail.com>
+     */
+     
+require 'vendor/autoload.php';
+
+use ChatterBotApi\ChatterBotFactory;
+use ChatterBotApi\ChatterBotType;
+
+
+$bot1 = ChatterBotFactory::create(ChatterBotType::CLEVERBOT);
+$bot1session = $bot1->createSession();
+
+$bot2 = ChatterBotFactory::create(ChatterBotType::PANDORABOTS, 'b0dafd24ee35a477');
+$bot2session = $bot2->createSession();
+
+$s = 'Hi';

--- a/php/ChatterBotApiTestOOP.php
+++ b/php/ChatterBotApiTestOOP.php
@@ -35,3 +35,12 @@ $bot2 = ChatterBotFactory::create(ChatterBotType::PANDORABOTS, 'b0dafd24ee35a477
 $bot2session = $bot2->createSession();
 
 $s = 'Hi';
+while (1) 
+{
+    echo "bot1> $s\n";
+    
+    $s = $bot2session->think($s);
+    echo "bot2> $s\n";
+    
+    $s = $bot1session->think($s);
+}

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,0 +1,7 @@
+{
+    "autoload": {
+        "psr-0": {
+            "ChatterBotApi\\": "."
+        }
+    }
+}


### PR DESCRIPTION
I was using the API and I didn' t like the way how it puts all these classes and functions into my global namespace, therefor I re-organized the structure a bit
- Every class exists in it' s own class and has a namespace [PSR-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md).
- Moved these `_utils_` functions into a "static" class.
- Fixed in this new version some bugs, e.g. sending content-type with the request and using `explode()` instead of `split()` (which is deprecated).

The current version (`chatterbotapi.php`) is still there and can co-exists with the this version perfectly. This (of this pull-request) is just a bit more convient and up-to-date.

The logic it self is **untouched**!!

Cheers,

Christian
